### PR TITLE
Fix listen address bug

### DIFF
--- a/overlay/usr/local/etc/rc.d/calibre_web
+++ b/overlay/usr/local/etc/rc.d/calibre_web
@@ -26,7 +26,7 @@ load_rc_config $name
 pidfile="/var/run/${name}/${name}.pid"
 
 #shebang error?
-command="env CALIBRE_DBPATH=${calibre_web_dbpath} python3 /usr/local/app/calibre-web/cps.py"
+command="env CALIBRE_DBPATH=${calibre_web_dbpath} python3 /usr/local/app/calibre-web/cps.py -i 0.0.0.0"
 #command_args ???
 #required_dirs="${calibre_web_dbpath}"
 


### PR DESCRIPTION
There seems to be a problem while trying to reach the calibre_web UI. Think I finally found something making it not being accessible (see plugin installation test here: https://cirrus-ci.com/task/6324386052440064).

The `cps` python seems to listen to localhost only, changing the listen address to 0.0.0.0 seems to fix the issue and make it reachable again.

Could be related to the issue in the parent repo: https://github.com/entuerto/iocage-plugin-calibre-web/issues/2