### PR TITLE
Add procname for service status support

### DIFF
--- a/overlay/usr/local/etc/rc.d/calibre_web
+++ b/overlay/usr/local/etc/rc.d/calibre_web
@@ -24,6 +24,7 @@ load_rc_config $name
 : ${calibre_web_logfile:=/var/log/calibre-web/calibre-web.log}
 
 pidfile="/var/run/${name}/${name}.pid"
+procname=python3
 
 #shebang error?
 command="env CALIBRE_DBPATH=${calibre_web_dbpath} python3 /usr/local/app/calibre-web/cps.py -i 0.0.0.0"


### PR DESCRIPTION
Currently `service calibre_web status` returns "not running" even though the service is up and running. See index repo test run e.g. here: https://cirrus-ci.com/task/4997409106296832