### PR TITLE
Fix undefined `installdir` in update

### DIFF
--- a/post_update.sh
+++ b/post_update.sh
@@ -7,7 +7,7 @@ echo "Update Calibre-Web installation"
 
 git_url="https://github.com/janeczku/calibre-web.git"
 
-installdir=$installdir
+installdir="/usr/local/app/calibre-web"
 
 echo "Re-init git"
 rm -rf $installdir/.git


### PR DESCRIPTION
Updating (on `12.2-RELEASE`) gives the following errors, because `installdir` is not defined in `post_update.sh`:

```
Running post_update.sh script
Update Calibre-Web installation
Re-init git
Update Calibre-Web installation
Re-init git
fatal: cannot change to 'init': No such file or directory
Setting git remote to https://github.com/janeczku/calibre-web.git
fatal: cannot change to 'init': No such file or directory
Setting git remote to https://github.com/janeczku/calibre-web.git
fatal: cannot change to 'remote': No such file or directory
Reset calibre-web to latest master
fatal: cannot change to 'remote': No such file or directory
Reset calibre-web to latest master
fatal: cannot change to 'fetch': No such file or directory
Reset calibre-web to latest master
fatal: cannot change to 'reset': No such file or directory
Git cleanup
fatal: cannot change to 'reset': No such file or directory
Git cleanup
fatal: cannot change to 'clean': No such file or directory
Installing requirements
fatal: cannot change to 'clean': No such file or directory
Installing requirements
ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/requirements.txt'
Installing requirements
ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/optional-requirements.txt'
Installing requirements
usage: chown [-fhvx] [-R [-H | -L | -P]] owner[:group] file ...
       chown [-fhvx] [-R [-H | -L | -P]] :group file ...
calibre_web_enable: NO -> YES
usage: chown [-fhvx] [-R [-H | -L | -P]] owner[:group] file ...
       chown [-fhvx] [-R [-H | -L | -P]] :group file ...
calibre_web is not running
usage: chown [-fhvx] [-R [-H | -L | -P]] owner[:group] file ...
       chown [-fhvx] [-R [-H | -L | -P]] :group file ...
Starting calibre_web
usage: chown [-fhvx] [-R [-H | -L | -P]] owner[:group] file ...
       chown [-fhvx] [-R [-H | -L | -P]] :group file ...
Traceback (most recent call last):
  File "/usr/local/app/calibre-web/cps.py", line 34, in <module>
    from cps import create_app
  File "/usr/local/app/calibre-web/cps/__init__.py", line 28, in <module>
    from babel import Locale as LC
ModuleNotFoundError: No module named 'babel'
```

I couldn't see an obvious way that `$installdir` was supposed to be defined elsewhere in 5b1d3acde5bd886996e73aa324802ccb6bbaaba4, so simply define it here.